### PR TITLE
feat: server-truth pricing, idempotency key, and 30-min session expiry

### DIFF
--- a/app/[locale]/checkout/page.tsx
+++ b/app/[locale]/checkout/page.tsx
@@ -47,12 +47,10 @@ export default function CheckoutPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          // Only send id + quantity — prices are looked up server-side
           items: items.map(i => ({
             id: i.product.id,
-            name: i.product.name_en,
-            price: i.product.price,
             quantity: i.quantity,
-            image: i.product.image_url,
           })),
           customerEmail: formData.email,
           customerName: formData.name,

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { createServerClient } from '@supabase/ssr';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 import { getSupabasePublicEnv, getSupabaseServiceRoleKey } from '@/lib/supabase/env';
+import { getProductsByIds } from '@/lib/data';
 
 // Helper: create admin-level client that bypasses RLS using service_role key
 function createAdminClient() {
@@ -43,6 +44,25 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // ── Server-truth pricing: look up real prices from lib/data.ts ──
+    const productIds = items.map((item: { id: string }) => item.id);
+    const productMap = getProductsByIds(productIds);
+
+    // Validate every product exists server-side
+    const serverItems = items.map((item: { id: string; quantity: number }) => {
+      const product = productMap.get(item.id);
+      if (!product) {
+        throw new Error(`Product not found: ${item.id}`);
+      }
+      return {
+        id: product.id,
+        name: product.name_en,
+        price: product.price,         // SERVER price — never from client
+        quantity: item.quantity,
+        image: product.image_url,
+      };
+    });
+
     // Create Supabase clients
     const supabase = await createClient();
     const admin = createAdminClient();
@@ -67,8 +87,8 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Calculate totals
-    const totalAmount = items.reduce(
+    // Calculate totals from SERVER prices (not client-supplied)
+    const totalAmount = serverItems.reduce(
       (sum: number, item: { price: number; quantity: number }) => 
         sum + item.price * item.quantity, 
       0
@@ -94,14 +114,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Create order items using admin client to bypass RLS
-    const orderItems = items.map((item: { 
-      id: string; 
-      name: string; 
-      price: number; 
-      quantity: number;
-      image?: string;
-    }) => ({
+    // Create order items from SERVER-verified data
+    const orderItems = serverItems.map((item: { id: string; name: string; price: number; quantity: number }) => ({
       order_id: order.id,
       product_id: item.id,
       product_name: item.name,
@@ -117,8 +131,8 @@ export async function POST(req: NextRequest) {
       console.error('Failed to create order items:', itemsError);
     }
 
-    // Create Stripe checkout session
-    const session = await createCheckoutSession(items, customerEmail, order.id, locale || 'en');
+    // Create Stripe checkout session with server-verified prices
+    const session = await createCheckoutSession(serverItems, customerEmail, order.id, locale || 'en');
 
     // Update order with Stripe session ID
     await admin

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,5 +1,17 @@
 import type { Product } from '@/lib/types';
 
+export function getProductById(id: string): Product | undefined {
+  return sampleProducts.find(p => p.id === id);
+}
+
+export function getProductsByIds(ids: string[]): Map<string, Product> {
+  const map = new Map<string, Product>();
+  for (const p of sampleProducts) {
+    if (ids.includes(p.id)) map.set(p.id, p);
+  }
+  return map;
+}
+
 export const sampleProducts: Product[] = [
   {
     id: '1',

--- a/lib/stripe/server.ts
+++ b/lib/stripe/server.ts
@@ -22,8 +22,18 @@ export const stripe = new Proxy({} as Stripe, {
   },
 });
 
+/**
+ * Create a Stripe Checkout Session with server-truth pricing.
+ *
+ * Accepts only product IDs + quantities — prices are looked up server-side
+ * from lib/data.ts so clients can never manipulate amounts.
+ *
+ * Security:
+ *  - Idempotency key per order prevents duplicate charges
+ *  - 30-minute session expiry limits the payment window
+ */
 export async function createCheckoutSession(
-  items: Array<{ name: string; price: number; quantity: number }>,
+  items: Array<{ id: string; quantity: number; name: string; price: number }>,
   customerEmail: string,
   orderId?: string,
   locale?: string
@@ -35,22 +45,29 @@ export async function createCheckoutSession(
       product_data: {
         name: item.name,
       },
-      unit_amount: Math.round(item.price * 100), // Convert to kuruş
+      unit_amount: Math.round(item.price * 100), // Server-verified price in kuruş
     },
     quantity: item.quantity,
   }));
 
-  const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
-    line_items: lineItems,
-    customer_email: customerEmail,
-    success_url: `${env.NEXT_PUBLIC_APP_URL}/${lang}/orders/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${env.NEXT_PUBLIC_APP_URL}/${lang}/cart?cancelled=true`,
-    metadata: {
-      orderId: orderId || '',
-      items: JSON.stringify(items),
+  // 30-minute expiry: session becomes invalid after this window
+  const expiresAt = Math.floor(Date.now() / 1000) + 30 * 60;
+
+  const session = await getStripe().checkout.sessions.create(
+    {
+      mode: 'payment',
+      line_items: lineItems,
+      customer_email: customerEmail,
+      expires_at: expiresAt,
+      success_url: `${env.NEXT_PUBLIC_APP_URL}/${lang}/orders/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${env.NEXT_PUBLIC_APP_URL}/${lang}/cart?cancelled=true`,
+      metadata: {
+        orderId: orderId || '',
+      },
     },
-  });
+    // Idempotency key: prevents duplicate sessions for the same order
+    orderId ? { idempotencyKey: `checkout_${orderId}` } : undefined
+  );
 
   return session;
 }


### PR DESCRIPTION
## Summary

Enforces server-authoritative pricing in the checkout flow. 
Clients now send only { id, quantity }, and all prices are resolved and validated on the server.

## Changes

- lib/data.ts: Added getProductById() and getProductsByIds() server lookup helpers
- lib/stripe/server.ts:
  - createCheckoutSession() now uses getStripe()
  - Adds expires_at (30 minutes)
  - Adds per-order idempotencyKey
- app/api/checkout/route.ts:
  - Validates product IDs server-side
  - Computes totals using server-side prices
  - Passes only server-verified items to Stripe
- app/[locale]/checkout/page.tsx:
  - Client now sends only { id, quantity }
  - Removed name, price, and image from payload

## Checklist

- [x] npm run lint passes
- [x] npm run typecheck passes
- [x] npm run build passes
- [x] No secrets in client bundles
- [x] No httpOnly: false introduced
- [x] Prices are server-truth (not from client)

## Testing

- Verified client request body contains only { id, quantity }
- Confirmed server resolves real product data before Stripe session creation
- Confirmed totals are computed exclusively from server-side pricing
- Verified successful end-to-end checkout flow

## Related

Security hardening of checkout payment flow.
