### PR TITLE
refactor(webhook): harden Stripe webhook with idempotency, transactio…

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,88 +1,260 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { stripe } from '@/lib/stripe/server';
-import { createClient } from '@supabase/supabase-js';
+import { getStripe } from '@/lib/stripe/server';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type Stripe from 'stripe';
 import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
 
+// ── Supabase admin client (service_role — bypasses RLS) ──────
 function createSupabaseAdminClient() {
   return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 }
 
+// ── Idempotency ──────────────────────────────────────────────
+/**
+ * INSERT the Stripe event ID into `stripe_events`.
+ * Returns `true` if this is a new event, `false` if already processed.
+ *
+ * The table uses a PRIMARY KEY on `event_id`, so a duplicate insert
+ * triggers a unique-violation (23505) which we treat as "already seen".
+ *
+ * If the table doesn't exist yet (migration not run), we log a warning
+ * and allow processing so the webhook isn't blocked.
+ */
+async function recordEvent(
+  supabase: SupabaseClient,
+  eventId: string,
+  eventType: string,
+): Promise<boolean> {
+  const { error } = await supabase
+    .from('stripe_events')
+    .insert({ event_id: eventId, event_type: eventType });
+
+  // unique_violation → already processed
+  if (error?.code === '23505') return false;
+
+  if (error) {
+    // Table may not exist yet — warn but don't block
+    logger.warn('webhook.idempotency_insert_failed', {
+      eventId,
+      code: error.code,
+      error: error.message,
+    });
+  }
+
+  return true;
+}
+
+// ── Main Handler ─────────────────────────────────────────────
 export async function POST(request: NextRequest) {
   const supabaseAdmin = createSupabaseAdminClient();
   const body = await request.text();
   const signature = request.headers.get('stripe-signature');
 
   if (!signature) {
+    logger.warn('webhook.missing_signature');
     return NextResponse.json(
       { error: 'Missing stripe signature' },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
   let event: Stripe.Event;
 
   try {
-    event = stripe.webhooks.constructEvent(
+    event = getStripe().webhooks.constructEvent(
       body,
       signature,
-      env.STRIPE_WEBHOOK_SECRET
+      env.STRIPE_WEBHOOK_SECRET,
     );
   } catch (err) {
-    console.error('Webhook signature verification failed:', err);
+    logger.error('webhook.signature_invalid', {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return NextResponse.json(
       { error: 'Invalid signature' },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
-  // Handle the event
-  switch (event.type) {
-    case 'checkout.session.completed': {
-      const session = event.data.object as Stripe.Checkout.Session;
-      
-      console.log('Payment successful for session:', session.id);
+  // ── Idempotency: skip already-processed events ─────────────
+  const isNew = await recordEvent(supabaseAdmin, event.id, event.type);
+  if (!isNew) {
+    logger.info('webhook.duplicate_skipped', {
+      eventId: event.id,
+      type: event.type,
+    });
+    return NextResponse.json({ received: true });
+  }
 
-      // Update order status to 'paid'
-      const { error } = await supabaseAdmin
-        .from('orders')
-        .update({ 
-          status: 'paid',
-          stripe_payment_intent_id: session.payment_intent as string,
-        })
-        .eq('stripe_session_id', session.id);
+  logger.info('webhook.processing', { eventId: event.id, type: event.type });
 
-      if (error) {
-        console.error('Failed to update order:', error);
+  // ── Route to handler ───────────────────────────────────────
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        await handleCheckoutCompleted(
+          supabaseAdmin,
+          event.data.object as Stripe.Checkout.Session,
+        );
+        break;
       }
 
-      // TODO: Send confirmation email
-      // TODO: Reduce stock
-      
-      break;
-    }
+      case 'checkout.session.expired': {
+        await handleCheckoutExpired(
+          supabaseAdmin,
+          event.data.object as Stripe.Checkout.Session,
+        );
+        break;
+      }
 
-    case 'checkout.session.expired': {
-      const session = event.data.object as Stripe.Checkout.Session;
-      
-      // Update order status to 'cancelled'
-      await supabaseAdmin
-        .from('orders')
-        .update({ status: 'cancelled' })
-        .eq('stripe_session_id', session.id);
-      
-      break;
-    }
+      case 'payment_intent.succeeded': {
+        handlePaymentIntentSucceeded(
+          event.data.object as Stripe.PaymentIntent,
+        );
+        break;
+      }
 
-    case 'payment_intent.payment_failed': {
-      const paymentIntent = event.data.object as Stripe.PaymentIntent;
-      console.log('Payment failed:', paymentIntent.id);
-      break;
-    }
+      case 'payment_intent.payment_failed': {
+        handlePaymentIntentFailed(
+          event.data.object as Stripe.PaymentIntent,
+        );
+        break;
+      }
 
-    default:
-      console.log(`Unhandled event type: ${event.type}`);
+      default:
+        logger.info('webhook.unhandled_type', { type: event.type });
+    }
+  } catch (err) {
+    logger.error('webhook.handler_error', {
+      eventId: event.id,
+      type: event.type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    // Return 500 so Stripe retries this event
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });
+}
+
+// ── checkout.session.completed ───────────────────────────────
+/**
+ * Uses the `process_payment_completed` RPC (Postgres function) to
+ * atomically update the order status AND award loyalty points in a
+ * single transaction.
+ *
+ * Falls back to a simple UPDATE if the RPC is not deployed yet.
+ */
+async function handleCheckoutCompleted(
+  supabase: SupabaseClient,
+  session: Stripe.Checkout.Session,
+) {
+  logger.info('webhook.checkout_completed', {
+    sessionId: session.id,
+    paymentIntent: session.payment_intent,
+    customerEmail: session.customer_email,
+  });
+
+  // Try transactional RPC first
+  const { data, error: rpcError } = await supabase.rpc(
+    'process_payment_completed',
+    {
+      p_stripe_session_id: session.id,
+      p_payment_intent_id: (session.payment_intent as string) || '',
+    },
+  );
+
+  if (rpcError) {
+    // RPC not deployed yet — fall back to simple update
+    logger.warn('webhook.rpc_unavailable_fallback', {
+      sessionId: session.id,
+      error: rpcError.message,
+    });
+
+    const { error: updateError } = await supabase
+      .from('orders')
+      .update({
+        status: 'paid',
+        stripe_payment_intent_id: session.payment_intent as string,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('stripe_session_id', session.id)
+      .eq('status', 'pending');
+
+    if (updateError) {
+      logger.error('webhook.order_update_failed', {
+        sessionId: session.id,
+        error: updateError.message,
+      });
+      throw updateError;
+    }
+
+    logger.info('webhook.order_paid_fallback', { sessionId: session.id });
+    return;
+  }
+
+  const result = data as {
+    success: boolean;
+    order_id?: string;
+    points_awarded?: number;
+    reason?: string;
+  } | null;
+
+  if (!result?.success) {
+    logger.warn('webhook.order_not_updated', {
+      sessionId: session.id,
+      reason: result?.reason,
+    });
+    return;
+  }
+
+  logger.info('webhook.order_paid', {
+    orderId: result.order_id,
+    pointsAwarded: result.points_awarded,
+  });
+}
+
+// ── checkout.session.expired ─────────────────────────────────
+async function handleCheckoutExpired(
+  supabase: SupabaseClient,
+  session: Stripe.Checkout.Session,
+) {
+  logger.info('webhook.checkout_expired', { sessionId: session.id });
+
+  const { error } = await supabase
+    .from('orders')
+    .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+    .eq('stripe_session_id', session.id)
+    .eq('status', 'pending'); // only cancel if still pending
+
+  if (error) {
+    logger.error('webhook.cancel_failed', {
+      sessionId: session.id,
+      error: error.message,
+    });
+    throw error;
+  }
+}
+
+// ── payment_intent.succeeded ─────────────────────────────────
+/**
+ * Order status is already updated via checkout.session.completed.
+ * This handler provides an additional confirmation audit log.
+ */
+function handlePaymentIntentSucceeded(pi: Stripe.PaymentIntent) {
+  logger.info('webhook.payment_intent_succeeded', {
+    paymentIntentId: pi.id,
+    amount: pi.amount,
+    currency: pi.currency,
+  });
+}
+
+// ── payment_intent.payment_failed ────────────────────────────
+function handlePaymentIntentFailed(pi: Stripe.PaymentIntent) {
+  logger.warn('webhook.payment_intent_failed', {
+    paymentIntentId: pi.id,
+    amount: pi.amount,
+    lastError: pi.last_payment_error?.message,
+  });
 }

--- a/scripts/004-stripe-events.sql
+++ b/scripts/004-stripe-events.sql
@@ -1,0 +1,88 @@
+-- =============================================
+-- PR4: Webhook Hardening — Stripe Events + Transaction RPC
+-- Run this in the Supabase SQL Editor after schema.sql
+-- =============================================
+
+-- ─── Idempotency table: prevents duplicate event processing ───
+CREATE TABLE IF NOT EXISTS stripe_events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  processed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_events_type ON stripe_events(event_type);
+
+-- RLS: only service_role can access (webhooks use admin client)
+ALTER TABLE stripe_events ENABLE ROW LEVEL SECURITY;
+
+-- ─── Transactional RPC: atomically update order + award loyalty ───
+-- Called from the webhook handler on checkout.session.completed.
+-- Runs inside a single Postgres transaction so order status and
+-- loyalty points are always consistent.
+CREATE OR REPLACE FUNCTION process_payment_completed(
+  p_stripe_session_id TEXT,
+  p_payment_intent_id TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER          -- runs with table-owner privileges
+SET search_path = public  -- prevent search_path injection
+AS $$
+DECLARE
+  v_order RECORD;
+  v_points INTEGER := 0;
+BEGIN
+  -- 1. Atomically mark order as paid (only if still pending)
+  UPDATE orders
+  SET status              = 'paid',
+      stripe_payment_intent_id = p_payment_intent_id,
+      updated_at          = NOW()
+  WHERE stripe_session_id = p_stripe_session_id
+    AND status            = 'pending'
+  RETURNING id, user_id, total INTO v_order;
+
+  IF v_order.id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'order_not_found_or_already_processed'
+    );
+  END IF;
+
+  -- 2. Award loyalty points (1 pt per 10 TRY) — only if tables exist
+  IF v_order.user_id IS NOT NULL
+     AND v_order.total > 0
+     AND EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = 'loyalty_points'
+     )
+  THEN
+    v_points := FLOOR(v_order.total / 10);
+
+    IF v_points > 0 THEN
+      -- Upsert loyalty record
+      INSERT INTO loyalty_points (user_id, total_points, lifetime_points)
+      VALUES (v_order.user_id, v_points, v_points)
+      ON CONFLICT (user_id) DO UPDATE
+      SET total_points    = loyalty_points.total_points    + EXCLUDED.total_points,
+          lifetime_points = loyalty_points.lifetime_points + EXCLUDED.lifetime_points,
+          updated_at      = NOW();
+
+      -- Record points transaction
+      INSERT INTO points_transactions (user_id, order_id, type, points, description)
+      VALUES (
+        v_order.user_id,
+        v_order.id,
+        'earned',
+        v_points,
+        'Order payment completed'
+      );
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',        true,
+    'order_id',       v_order.id,
+    'points_awarded', v_points
+  );
+END;
+$$;


### PR DESCRIPTION
- Add stripe_events table for idempotency (INSERT ON CONFLICT skip)
- Create process_payment_completed RPC: atomic order update + loyalty points
- Replace console.log/error with structured logger (JSON, ISO timestamps)
- Add payment_intent.succeeded handler for audit trail
- Use getStripe() singleton instead of deprecated stripe proxy
- Add graceful fallback when RPC not deployed (simple UPDATE)
- Return 500 on handler errors so Stripe retries the event
- Guard checkout.session.expired to only cancel pending orders

Migration: scripts/004-stripe-events.sql
Verified: lint 0 ✔ | typecheck 0 ✔ | build pass ✔
