### PR TITLE
refactor(auth): add RBAC admin guard + fix cookie passthrough

### DIFF
--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -1,0 +1,82 @@
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+
+export type AdminRole = 'super_admin' | 'admin' | 'manager' | 'staff';
+
+interface AdminInfo {
+  userId: string;
+  role: AdminRole;
+  permissions: Record<string, boolean>;
+}
+
+/**
+ * Check whether the given user ID has an admin_users record.
+ * Returns the role + permissions when the user is an admin, `null` otherwise.
+ */
+export async function getAdminInfo(userId: string): Promise<AdminInfo | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('admin_users')
+    .select('role, permissions')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    logger.error('admin_users lookup failed', { userId, error: error.message });
+    return null;
+  }
+
+  if (!data) return null;
+
+  return {
+    userId,
+    role: data.role as AdminRole,
+    permissions: (data.permissions ?? {}) as Record<string, boolean>,
+  };
+}
+
+/**
+ * Convenience boolean: is the current session user an admin?
+ */
+export async function isAdmin(): Promise<boolean> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return false;
+  const info = await getAdminInfo(user.id);
+  return info !== null;
+}
+
+/**
+ * Guard for API route handlers.
+ * Returns the AdminInfo when the caller is an admin, or a 401/403 NextResponse.
+ *
+ * Usage:
+ * ```ts
+ * const result = await requireAdmin();
+ * if (result instanceof NextResponse) return result;
+ * const admin = result; // AdminInfo
+ * ```
+ */
+export async function requireAdmin(): Promise<AdminInfo | NextResponse> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    logger.warn('requireAdmin: unauthenticated request');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const info = await getAdminInfo(user.id);
+
+  if (!info) {
+    logger.warn('requireAdmin: non-admin user attempted admin action', {
+      userId: user.id,
+      email: user.email,
+    });
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return info;
+}

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -6,6 +6,12 @@ export function isProtectedPath(request: NextRequest): boolean {
   return PROTECTED_ROUTES.some((path) => request.nextUrl.pathname.includes(path));
 }
 
+/** Returns true when the request targets an admin-only path (e.g. /en/admin/*). */
+export function isAdminPath(request: NextRequest): boolean {
+  // Matches /<locale>/admin and /<locale>/admin/*
+  return /^\/(tr|en)\/admin(\/|$)/.test(request.nextUrl.pathname);
+}
+
 export function detectLocaleFromPath(pathname: string): 'tr' | 'en' {
   return pathname.startsWith('/tr') ? 'tr' : 'en';
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,7 +2,7 @@ import createMiddleware from 'next-intl/middleware';
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { routing } from './i18n/routing';
-import { detectLocaleFromPath, isProtectedPath } from '@/lib/middleware';
+import { detectLocaleFromPath, isProtectedPath, isAdminPath } from '@/lib/middleware';
 import { logger } from '@/lib/logger';
 import { getSupabasePublicEnv } from '@/lib/supabase/env';
 
@@ -27,9 +27,9 @@ export async function proxy(request: NextRequest) {
             request.cookies.set(name, value)
           );
           // Set cookies on the existing intl response instead of replacing it
-          // Force httpOnly: false so browser JS can read auth cookies
+          // Pass Supabase cookie options through unchanged (httpOnly, Secure, SameSite)
           cookiesToSet.forEach(({ name, value, options }) =>
-            response.cookies.set(name, value, { ...options })
+            response.cookies.set(name, value, options)
           );
         },
       },
@@ -50,6 +50,26 @@ export async function proxy(request: NextRequest) {
       locale,
     });
     return NextResponse.redirect(url);
+  }
+
+  // ── Admin RBAC: server-side guard for /admin routes ──
+  if (isAdminPath(request) && user) {
+    const { data: adminRecord } = await supabase
+      .from('admin_users')
+      .select('role')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!adminRecord) {
+      const locale = detectLocaleFromPath(request.nextUrl.pathname);
+      logger.warn('Non-admin user blocked from admin route', {
+        userId: user.id,
+        path: request.nextUrl.pathname,
+      });
+      const url = request.nextUrl.clone();
+      url.pathname = `/${locale}`;
+      return NextResponse.redirect(url);
+    }
   }
 
   return response;


### PR DESCRIPTION

## Summary

- Remove misleading 'Force httpOnly: false' comment from proxy.ts
- Pass Supabase cookie options through unchanged (httpOnly, Secure, SameSite)
- Add lib/auth/admin.ts with isAdmin(), getAdminInfo(), requireAdmin() helpers
- Add isAdminPath() helper to lib/middleware.ts
- Add server-side admin route protection in proxy middleware
  (non-admin users redirected away from /admin/* paths)
- Verify: lint 0, tsc 0, build OK (55 routes