### PR TITLE
refactor(security): add CSRF origin check, rate limits, CSP, input sa…

### DIFF
--- a/app/api/checkout/gift-card/route.ts
+++ b/app/api/checkout/gift-card/route.ts
@@ -1,22 +1,46 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe/server';
 import { env } from '@/lib/env';
+import { rateLimit, getClientIP } from '@/lib/rate-limit';
+import { validateOrigin, sanitizeString, isValidEmail, clampNumber } from '@/lib/security';
 
 export async function POST(req: NextRequest) {
-  try {
-    const { 
-      amount, 
-      senderName, 
-      senderEmail, 
-      recipientName, 
-      recipientEmail, 
-      message,
-      locale = 'en' 
-    } = await req.json();
+  // ── CSRF: verify request origin ──
+  const originError = validateOrigin(req);
+  if (originError) return originError;
 
-    if (!amount || !senderName || !senderEmail || !recipientName || !recipientEmail) {
+  // Rate limit: 3 gift-card checkouts per minute per IP
+  const ip = getClientIP(req);
+  const limiter = rateLimit(`gift-checkout:${ip}`, { maxRequests: 3, windowSizeSeconds: 60 });
+  if (!limiter.success) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    );
+  }
+
+  try {
+    const body = await req.json();
+
+    // Sanitize inputs
+    const amount = clampNumber(Number(body.amount) || 0, 10, 5000);
+    const senderName = sanitizeString(body.senderName ?? '');
+    const senderEmail = sanitizeString(body.senderEmail ?? '');
+    const recipientName = sanitizeString(body.recipientName ?? '');
+    const recipientEmail = sanitizeString(body.recipientEmail ?? '');
+    const message = sanitizeString(body.message ?? '');
+    const locale = body.locale || 'en';
+
+    if (!senderName || !senderEmail || !recipientName || !recipientEmail) {
       return NextResponse.json(
         { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidEmail(senderEmail) || !isValidEmail(recipientEmail)) {
+      return NextResponse.json(
+        { error: 'Invalid email address' },
         { status: 400 }
       );
     }

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -5,6 +5,7 @@ import { createServerClient } from '@supabase/ssr';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 import { getSupabasePublicEnv, getSupabaseServiceRoleKey } from '@/lib/supabase/env';
 import { getProductsByIds } from '@/lib/data';
+import { validateOrigin, sanitizeString, isValidEmail } from '@/lib/security';
 
 // Helper: create admin-level client that bypasses RLS using service_role key
 function createAdminClient() {
@@ -24,6 +25,10 @@ function createAdminClient() {
 }
 
 export async function POST(req: NextRequest) {
+  // ── CSRF: verify request origin ──
+  const originError = validateOrigin(req);
+  if (originError) return originError;
+
   // Rate limit: 5 checkout attempts per minute per IP
   const ip = getClientIP(req);
   const limiter = rateLimit(`checkout:${ip}`, { maxRequests: 5, windowSizeSeconds: 60 });
@@ -35,11 +40,23 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { items, customerEmail, customerName, customerAddress, locale } = await req.json();
+    const { items, customerEmail: rawEmail, customerName: rawName, customerAddress: rawAddress, locale } = await req.json();
+
+    // Sanitize user-supplied strings
+    const customerEmail = sanitizeString(rawEmail ?? '');
+    const customerName = sanitizeString(rawName ?? '');
+    const customerAddress = sanitizeString(rawAddress ?? '');
 
     if (!items || !items.length || !customerEmail) {
       return NextResponse.json(
         { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidEmail(customerEmail)) {
+      return NextResponse.json(
+        { error: 'Invalid email address' },
         { status: 400 }
       );
     }

--- a/app/api/email/gift-card/route.ts
+++ b/app/api/email/gift-card/route.ts
@@ -2,12 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 import { env } from '@/lib/env';
+import { validateOrigin } from '@/lib/security';
 
 function getResendClient(): Resend {
   return new Resend(env.RESEND_API_KEY);
 }
 
 export async function POST(request: NextRequest) {
+  // ── CSRF: verify request origin ──
+  const originError = validateOrigin(request);
+  if (originError) return originError;
+
   // Rate limit: 3 gift card emails per minute per IP
   const ip = getClientIP(request);
   const limiter = rateLimit(`gift-card:${ip}`, { maxRequests: 3, windowSizeSeconds: 60 });

--- a/app/api/email/send/route.ts
+++ b/app/api/email/send/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 import { env } from '@/lib/env';
+import { validateOrigin, sanitizeString } from '@/lib/security';
 
 function getResendClient() {
   return new Resend(env.RESEND_API_KEY);
@@ -59,6 +60,10 @@ const emailTemplates = {
 };
 
 export async function POST(request: NextRequest) {
+  // ── CSRF: verify request origin ──
+  const originError = validateOrigin(request);
+  if (originError) return originError;
+
   // Rate limit: 3 emails per minute per IP
   const ip = getClientIP(request);
   const limiter = rateLimit(`email:${ip}`, { maxRequests: 3, windowSizeSeconds: 60 });
@@ -70,7 +75,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { type, to, data, locale = 'tr' } = await request.json();
+    const body = await request.json();
+    const type = sanitizeString(body.type ?? '');
+    const to = sanitizeString(body.to ?? '');
+    const data = body.data;
+    const locale = body.locale || 'tr';
     const resend = getResendClient();
 
     if (!emailTemplates[type as keyof typeof emailTemplates]) {

--- a/lib/auth/actions.ts
+++ b/lib/auth/actions.ts
@@ -3,7 +3,29 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
 import { env } from '@/lib/env';
+import { rateLimit } from '@/lib/rate-limit';
+import { sanitizeString, isValidEmail } from '@/lib/security';
+import { logger } from '@/lib/logger';
+
+/** Extract client IP from server action request headers. */
+async function getActionIP(): Promise<string> {
+  const h = await headers();
+  return h.get('x-forwarded-for')?.split(',')[0].trim()
+    ?? h.get('x-real-ip')
+    ?? '127.0.0.1';
+}
+
+function checkAuthRateLimit(action: string, ip: string): AuthResult | null {
+  // 5 attempts per minute per IP per action
+  const result = rateLimit(`auth:${action}:${ip}`, { maxRequests: 5, windowSizeSeconds: 60 });
+  if (!result.success) {
+    logger.warn('Auth rate limit exceeded', { action, ip, remaining: result.remaining });
+    return { success: false, error: 'Too many attempts. Please try again later.' };
+  }
+  return null;
+}
 
 export interface AuthResult {
   success: boolean;
@@ -11,12 +33,20 @@ export interface AuthResult {
 }
 
 export async function signIn(formData: FormData): Promise<AuthResult> {
-  const email = formData.get('email') as string;
+  const ip = await getActionIP();
+  const limited = checkAuthRateLimit('signIn', ip);
+  if (limited) return limited;
+
+  const email = sanitizeString(formData.get('email') as string ?? '');
   const password = formData.get('password') as string;
   const locale = (formData.get('locale') as string) || 'en';
 
   if (!email || !password) {
     return { success: false, error: 'Email and password are required' };
+  }
+
+  if (!isValidEmail(email)) {
+    return { success: false, error: 'Invalid email address' };
   }
 
   const supabase = await createClient();
@@ -35,13 +65,21 @@ export async function signIn(formData: FormData): Promise<AuthResult> {
 }
 
 export async function signUp(formData: FormData): Promise<AuthResult> {
-  const email = formData.get('email') as string;
+  const ip = await getActionIP();
+  const limited = checkAuthRateLimit('signUp', ip);
+  if (limited) return limited;
+
+  const email = sanitizeString(formData.get('email') as string ?? '');
   const password = formData.get('password') as string;
-  const fullName = formData.get('fullName') as string;
+  const fullName = sanitizeString(formData.get('fullName') as string ?? '');
   const locale = (formData.get('locale') as string) || 'en';
 
   if (!email || !password) {
     return { success: false, error: 'Email and password are required' };
+  }
+
+  if (!isValidEmail(email)) {
+    return { success: false, error: 'Invalid email address' };
   }
 
   const supabase = await createClient();
@@ -98,11 +136,19 @@ export async function signOut(): Promise<void> {
 }
 
 export async function forgotPassword(formData: FormData): Promise<AuthResult> {
-  const email = formData.get('email') as string;
+  const ip = await getActionIP();
+  const limited = checkAuthRateLimit('forgotPassword', ip);
+  if (limited) return limited;
+
+  const email = sanitizeString(formData.get('email') as string ?? '');
   const locale = (formData.get('locale') as string) || 'en';
 
   if (!email) {
     return { success: false, error: 'Email is required' };
+  }
+
+  if (!isValidEmail(email)) {
+    return { success: false, error: 'Invalid email address' };
   }
 
   const supabase = await createClient();

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/lib/env';
+import { logger } from '@/lib/logger';
+
+// ─── CSRF / Origin validation ─────────────────────────────────
+
+/**
+ * Allowed origins derived from the configured app/site URLs.
+ * Includes localhost for development.
+ */
+function getAllowedOrigins(): Set<string> {
+  const origins = new Set<string>();
+
+  for (const raw of [env.NEXT_PUBLIC_APP_URL, env.NEXT_PUBLIC_SITE_URL]) {
+    try {
+      const { origin } = new URL(raw);
+      origins.add(origin);
+    } catch {
+      // Skip malformed URLs
+    }
+  }
+
+  // Always allow localhost in development
+  if (env.isDevelopment) {
+    origins.add('http://localhost:3000');
+    origins.add('http://127.0.0.1:3000');
+  }
+
+  return origins;
+}
+
+/**
+ * Verify that the request originates from a trusted origin.
+ *
+ * Checks the `Origin` header first (set by fetch/XHR on mutations),
+ * then falls back to `Referer`. Rejects requests with no origin signal
+ * unless they come from a server-to-server context (no Origin + no Referer
+ * is acceptable for webhooks — guard those separately).
+ *
+ * @returns `null` when the origin is valid, or a 403 `NextResponse`.
+ */
+export function validateOrigin(req: NextRequest): NextResponse | null {
+  const origin = req.headers.get('origin');
+  const referer = req.headers.get('referer');
+
+  // Webhooks legitimately arrive without Origin/Referer — skip there.
+  // Callers that need to exempt specific routes can check before calling.
+
+  const allowed = getAllowedOrigins();
+
+  // Fast-path: Origin header present and allowed
+  if (origin) {
+    if (allowed.has(origin)) return null;
+
+    logger.warn('Origin check failed', { origin, allowed: [...allowed] });
+    return NextResponse.json(
+      { error: 'Forbidden: origin not allowed' },
+      { status: 403 },
+    );
+  }
+
+  // Fallback: check Referer header (preflight-less simple requests)
+  if (referer) {
+    try {
+      const refOrigin = new URL(referer).origin;
+      if (allowed.has(refOrigin)) return null;
+    } catch {
+      // malformed referer — reject
+    }
+
+    logger.warn('Referer check failed', { referer });
+    return NextResponse.json(
+      { error: 'Forbidden: origin not allowed' },
+      { status: 403 },
+    );
+  }
+
+  // Neither Origin nor Referer present
+  // In production, reject; in development, allow for testing tools
+  if (env.isProduction) {
+    logger.warn('Missing Origin and Referer headers on mutation request', {
+      path: req.nextUrl.pathname,
+    });
+    return NextResponse.json(
+      { error: 'Forbidden: missing origin' },
+      { status: 403 },
+    );
+  }
+
+  return null;
+}
+
+// ─── Input sanitization ───────────────────────────────────────
+
+/**
+ * Strip HTML tags and trim whitespace from a string.
+ * Prevents XSS when user-supplied text is later rendered or stored.
+ */
+export function sanitizeString(input: string): string {
+  return input
+    .replace(/<[^>]*>/g, '')   // strip HTML tags
+    .replace(/&[#\w]+;/g, '')  // strip HTML entities
+    .trim();
+}
+
+/**
+ * Sanitize all string values in a shallow object.
+ * Useful for cleaning an entire `req.json()` payload in one call.
+ */
+export function sanitizePayload<T extends Record<string, unknown>>(payload: T): T {
+  const clean = { ...payload };
+  for (const key of Object.keys(clean)) {
+    const val = clean[key];
+    if (typeof val === 'string') {
+      (clean as Record<string, unknown>)[key] = sanitizeString(val);
+    }
+  }
+  return clean;
+}
+
+/**
+ * Validate that an email looks structurally valid.
+ * Not a full RFC 5322 check — just enough to reject obvious junk.
+ */
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ * Clamp a numeric value within a safe range.
+ */
+export function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -60,6 +60,22 @@ const nextConfig: NextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+              "img-src 'self' data: blob: https://*.supabase.co https://lh3.googleusercontent.com",
+              "font-src 'self' https://fonts.gstatic.com",
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com",
+              "frame-src https://js.stripe.com https://hooks.stripe.com",
+              "object-src 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+              "frame-ancestors 'none'",
+            ].join('; '),
+          },
         ],
       },
       // ── Static asset caching ──────────────────────────────


### PR DESCRIPTION


## Summary
- Add lib/security.ts with validateOrigin(), sanitizeString(), sanitizePayload(), isValidEmail(), clampNumber()
- Add CSRF origin validation to all mutation API routes (checkout, gift-card, email)
- Add rate limiting to auth server actions (signIn, signUp, forgotPassword): 5 req/min/IP
- Add rate limiting to gift-card checkout: 3 req/min/IP
- Add Content-Security-Policy header in next.config.ts (Stripe, Supabase, Google Fonts whitelisted)
- Add input sanitization (HTML strip + email validation) to checkout, gift-card, email routes
- Add email format validation to auth actions
- Verify: lint 0, tsc 0, build OK (55 routes)