### PR TITLE
[16] governance: PII classification, GDPR plan, audit log append-only…

### DIFF
--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -1,0 +1,167 @@
+# Backup & Restore Procedure
+
+> Disaster recovery plan for Glazed & Sipped Supabase database.
+
+---
+
+## 1. Automated Backups (Supabase)
+
+Supabase Pro plan provides:
+- **Daily automated backups** with 7-day retention.
+- **Point-in-time recovery (PITR)** — restore to any second within the retention window.
+
+Access via: Supabase Dashboard → Settings → Database → Backups.
+
+---
+
+## 2. Manual Backup
+
+### Prerequisites
+```bash
+# Install PostgreSQL client tools
+# Ensure DATABASE_URL is set (from Supabase Dashboard → Settings → Database)
+```
+
+### Full Dump
+```bash
+pg_dump "$DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --format=custom \
+  --file=backup_$(date +%Y%m%d_%H%M%S).dump
+```
+
+### Schema-Only Dump
+```bash
+pg_dump "$DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --schema-only \
+  --file=schema_$(date +%Y%m%d).sql
+```
+
+### Tables-Only Dump (Data)
+```bash
+pg_dump "$DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --data-only \
+  --file=data_$(date +%Y%m%d).dump
+```
+
+---
+
+## 3. Restore
+
+### To a Fresh Database
+```bash
+pg_restore \
+  --dbname="$TARGET_DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --clean \
+  --if-exists \
+  backup_YYYYMMDD_HHMMSS.dump
+```
+
+### To Existing Database (Additive)
+```bash
+pg_restore \
+  --dbname="$DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --data-only \
+  data_YYYYMMDD.dump
+```
+
+---
+
+## 4. Post-Restore Validation
+
+Run these checks after every restore:
+
+### Row Count Verification
+```sql
+SELECT 'profiles'   AS t, COUNT(*) FROM profiles
+UNION ALL
+SELECT 'orders'     AS t, COUNT(*) FROM orders
+UNION ALL
+SELECT 'order_items' AS t, COUNT(*) FROM order_items
+UNION ALL
+SELECT 'products'   AS t, COUNT(*) FROM products
+UNION ALL
+SELECT 'audit_log'  AS t, COUNT(*) FROM audit_log
+UNION ALL
+SELECT 'stores'     AS t, COUNT(*) FROM stores;
+```
+
+### Integrity Checks
+```sql
+-- Orphaned order items (should return 0)
+SELECT COUNT(*) FROM order_items oi
+LEFT JOIN orders o ON oi.order_id = o.id
+WHERE o.id IS NULL;
+
+-- Profiles without auth user (should return 0)
+SELECT COUNT(*) FROM profiles p
+LEFT JOIN auth.users u ON p.id = u.id
+WHERE u.id IS NULL;
+
+-- Orders with invalid user_id (should return 0)
+SELECT COUNT(*) FROM orders o
+WHERE o.user_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM profiles WHERE id = o.user_id);
+```
+
+### Application Health Check
+```bash
+# Verify the app can connect and serve data
+curl -f https://your-domain.com/api/products
+curl -f https://your-domain.com/api/stores
+```
+
+---
+
+## 5. Backup Schedule (Recommended)
+
+| Type | Frequency | Retention | Storage |
+|------|-----------|-----------|---------|
+| Supabase auto backup | Daily | 7 days | Supabase (managed) |
+| Manual full dump | Weekly | 30 days | Cloud storage (S3/GCS) |
+| Schema dump | Before each migration | Indefinite | Git repository |
+| Pre-migration snapshot | Before running migrations | 7 days | Cloud storage |
+
+---
+
+## 6. Migration Rollback
+
+If a migration fails:
+
+1. **Restore from pre-migration snapshot:**
+   ```bash
+   pg_restore --dbname="$DATABASE_URL" --clean --if-exists pre_migration.dump
+   ```
+
+2. **Or use Supabase PITR:**
+   - Go to Dashboard → Settings → Database → Backups
+   - Select a timestamp before the migration ran
+   - Click "Restore"
+
+3. **Fix the migration SQL** and re-run.
+
+All migrations use `BEGIN; ... COMMIT;` transactions, so a failed migration auto-rolls back.
+
+---
+
+## 7. Disaster Recovery Runbook
+
+| Step | Action | Owner | SLA |
+|------|--------|-------|-----|
+| 1 | Detect outage (monitoring/alerts) | On-call | < 5 min |
+| 2 | Assess: is it app-level or data-level? | On-call | < 15 min |
+| 3a | App-level → redeploy from last good commit | DevOps | < 30 min |
+| 3b | Data-level → restore from latest backup | DevOps | < 1 hour |
+| 4 | Run post-restore validation (Section 4) | DevOps | < 15 min |
+| 5 | Verify application health | DevOps | < 5 min |
+| 6 | Notify stakeholders | On-call | < 2 hours |
+| 7 | Post-mortem | Team | < 1 week |

--- a/docs/GDPR.md
+++ b/docs/GDPR.md
@@ -1,0 +1,107 @@
+# GDPR-ish Data Management Plan
+
+> Data subject rights implementation for Glazed & Sipped.
+> Not legal advice — consult a DPO for production compliance.
+
+---
+
+## 1. Right to Access (Data Export)
+
+### Current Status: Documented (endpoint planned)
+
+**Future Endpoint:** `POST /api/user/export`
+
+**Scope:** All data associated with the authenticated user:
+
+| Table | Exported Fields |
+|-------|-----------------|
+| `profiles` | All columns |
+| `orders` + `order_items` | All orders (including soft-deleted) |
+| `loyalty_points` + `points_transactions` | Balance + history |
+| `gift_cards` | Cards purchased by user |
+| `subscriptions` + `subscription_deliveries` | Subscription data |
+| `reviews` | User's reviews |
+| `referrals` + `referral_codes` | Referral data |
+| `notifications` | Notification history |
+
+**Format:** JSON bundle (one file per table) + CSV summary.
+
+**Authentication:** Requires active session + email confirmation.
+
+**Rate Limit:** 1 export per 24 hours per user.
+
+---
+
+## 2. Right to Erasure (Data Deletion)
+
+### Current Status: Documented (endpoint planned)
+
+**Future Endpoint:** `POST /api/user/delete`
+
+**Deletion Strategy:**
+
+| Step | Action | Method |
+|------|--------|--------|
+| 1 | Cancel active subscriptions | Set status = 'cancelled', null out Stripe IDs |
+| 2 | Soft-delete orders | Set `deleted_at` = NOW() |
+| 3 | Anonymise profile | Replace PII with `[deleted]`, null phone/address |
+| 4 | Deactivate gift cards | Set `is_active = false` |
+| 5 | Delete loyalty data | Hard-delete `loyalty_points` + `points_transactions` |
+| 6 | Delete reviews | Hard-delete (or anonymise author) |
+| 7 | Delete notifications | Hard-delete |
+| 8 | Revoke auth session | `supabase.auth.admin.deleteUser(userId)` |
+| 9 | Emit audit log | `action: 'user.delete_request'` (no PII in log) |
+
+**Legal Hold Exception:**
+- Orders required for tax/finance compliance retain: `id`, `total`, `tax`, `status`, `created_at`.
+- All PII columns (`user_email`, `user_name`, `user_phone`, `user_address`) are set to `[redacted]`.
+
+**Cooling-Off Period:** 30 days. During this window the account is deactivated but recoverable. After 30 days, hard-delete is irreversible.
+
+---
+
+## 3. Right to Rectification
+
+Users can update their profile data via the `/account` page at any time:
+- Full name, phone, address, avatar.
+- Email changes require re-verification through Supabase Auth.
+
+---
+
+## 4. Data Minimisation
+
+| Principle | Implementation |
+|-----------|----------------|
+| Collect only what's needed | Checkout requires: name, email, phone, address. No extra fields. |
+| Ephemeral cart | Cart stored in `localStorage` with 2-day expiry. Never persisted server-side. |
+| No tracking cookies | No third-party analytics. Web Vitals beacon to own endpoint only. |
+| Minimal logging | P1 data never logged. Request IDs used for correlation instead. |
+
+---
+
+## 5. Breach Notification Plan
+
+| Step | Action | Timeline |
+|------|--------|----------|
+| 1 | Detect breach (logs, alerts, Stripe notification) | Immediate |
+| 2 | Assess scope: which tables, how many users | Within 4 hours |
+| 3 | Rotate all secrets (Supabase, Stripe, JWT) | Within 4 hours |
+| 4 | Notify affected users via email | Within 72 hours |
+| 5 | File incident report | Within 72 hours |
+| 6 | Post-mortem + remediation | Within 2 weeks |
+
+---
+
+## 6. Audit Trail
+
+All data governance actions are recorded in `audit_log`:
+
+| Action | Trigger |
+|--------|---------|
+| `user.export_request` | Data export initiated |
+| `user.delete_request` | Account deletion initiated |
+| `user.delete_completed` | Account hard-deleted after cooling-off |
+| `user.profile_updated` | Profile PII changed |
+| `admin.data_access` | Admin views user PII |
+
+The audit log is **append-only** (enforced by migration `007_audit_log_append_only.sql`).

--- a/docs/PII.md
+++ b/docs/PII.md
@@ -1,0 +1,134 @@
+# PII Classification
+
+> Personally Identifiable Information inventory for Glazed & Sipped.
+
+## Data Sensitivity Levels
+
+| Level | Label | Description | Examples |
+|-------|-------|-------------|----------|
+| **P0** | Highly Sensitive | Auth secrets, tokens, keys | Supabase service role key, Stripe secret key, password reset tokens |
+| **P1** | Sensitive PII | Data that can directly identify a person | Email, phone, address, payment identifiers |
+| **P2** | Personal | Data that identifies a person in context | Full name, user ID, avatar URL, referral code |
+| **P3** | Operational | Non-identifying business data | Order totals, product metadata, analytics events |
+
+---
+
+## Field Inventory
+
+### `profiles`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `id` | P2 | UUID, links to auth.users |
+| `email` | P1 | Primary identifier |
+| `full_name` | P2 | |
+| `phone` | P1 | |
+| `address` | P1 | Free-text delivery address |
+| `avatar_url` | P2 | May contain Google avatar URL |
+| `referral_code` | P2 | Unique per user |
+| `referred_by` | P2 | UUID of referrer |
+
+### `orders`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `id` | P3 | |
+| `user_id` | P2 | FK to profiles |
+| `user_email` | P1 | Denornalised copy for order fulfillment |
+| `user_name` | P2 | Denormalised copy |
+| `user_phone` | P1 | Denormalised copy |
+| `user_address` | P1 | Denormalised copy |
+| `stripe_session_id` | P1 | Payment identifier |
+| `stripe_payment_intent_id` | P1 | Payment identifier |
+| `status`, `subtotal`, `tax`, `total` | P3 | |
+| `deleted_at` | P3 | Soft-delete timestamp |
+
+### `order_items`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| All columns | P3 | No PII — product metadata + quantities |
+
+### `gift_cards`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `purchaser_id` | P2 | UUID |
+| `purchaser_email` | P1 | |
+| `recipient_email` | P1 | |
+| `recipient_name` | P2 | |
+| `message` | P2 | Free-text, may contain personal content |
+| `code` | P3 | Gift card code, not PII |
+
+### `subscriptions`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `user_id` | P2 | FK to profiles |
+| `stripe_subscription_id` | P1 | Payment identifier |
+| `stripe_customer_id` | P1 | Payment identifier |
+| Other columns | P3 | Plan metadata |
+
+### `loyalty_points` / `points_transactions`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `user_id` | P2 | FK to profiles |
+| Other columns | P3 | Points metadata |
+
+### `referrals` / `referral_codes`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `referrer_id`, `referred_id` | P2 | UUIDs |
+| `referral_code`, `code` | P2 | Unique per user |
+
+### `reviews`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `user_id` | P2 | FK to profiles |
+| `content`, `title` | P2 | May contain personal opinions |
+| `image_urls` | P2 | User-uploaded images |
+
+### `notifications`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `user_id` | P2 | FK to profiles |
+| `recipient` | P1 | Email or phone |
+| `content` | P2 | May contain personal data |
+
+### `audit_log`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `actor_id` | P2 | UUID of acting user |
+| `ip_address` | P1 | Can identify a person |
+| `changes` | P1/P2 | JSONB — may contain PII if capturing field diffs |
+
+### `stripe_events`
+
+| Column | Level | Notes |
+|--------|-------|-------|
+| `stripe_event_id` | P1 | Stripe identifier |
+| `payload` | P1 | Raw Stripe event, may contain customer info |
+
+---
+
+## Handling Rules
+
+1. **P0** — Never stored in the database. Environment variables only. Never logged.
+2. **P1** — Encrypted at rest (Supabase default). Never written to application logs. Mask in error messages (e.g., `j***@example.com`).
+3. **P2** — Acceptable in logs during development; redact in production logs. Include in data export.
+4. **P3** — No special handling required.
+
+## Retention Policy
+
+| Data | Retention | Deletion Method |
+|------|-----------|-----------------|
+| Audit logs | 12 months (configurable) | Automated cleanup job (future) |
+| Orders (soft-deleted) | 90 days after soft-delete | Hard-delete via scheduled job |
+| Stripe events | 90 days | Automated cleanup |
+| Analytics events | 6 months | Automated cleanup |
+| User profiles | Until account deletion | GDPR delete flow (see [GDPR.md](GDPR.md)) |

--- a/supabase/migrations/007_audit_log_append_only.sql
+++ b/supabase/migrations/007_audit_log_append_only.sql
@@ -1,0 +1,48 @@
+-- =============================================
+-- 007: Audit log append-only enforcement
+-- Depends on: 005_soft_delete_audit
+-- Idempotent: safe to re-run at any time
+-- =============================================
+BEGIN;
+
+-- ─── 1. Trigger function that blocks mutation ───────────────
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log is append-only — UPDATE and DELETE are forbidden';
+END;
+$$ LANGUAGE plpgsql;
+
+-- ─── 2. Block UPDATE ────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS audit_log_no_update ON audit_log;
+CREATE TRIGGER audit_log_no_update
+  BEFORE UPDATE ON audit_log
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_mutation();
+
+-- ─── 3. Block DELETE ────────────────────────────────────────
+
+DROP TRIGGER IF EXISTS audit_log_no_delete ON audit_log;
+CREATE TRIGGER audit_log_no_delete
+  BEFORE DELETE ON audit_log
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_mutation();
+
+-- ─── 4. Restrict RLS: no UPDATE/DELETE policies ─────────────
+-- (005 already only grants SELECT to admins.
+--  INSERT is service_role only, no anon/auth policy needed.)
+
+-- Explicitly deny UPDATE/DELETE for all roles except superuser:
+DROP POLICY IF EXISTS "No one can update audit log" ON audit_log;
+CREATE POLICY "No one can update audit log"
+  ON audit_log FOR UPDATE
+  USING (false);
+
+DROP POLICY IF EXISTS "No one can delete audit log" ON audit_log;
+CREATE POLICY "No one can delete audit log"
+  ON audit_log FOR DELETE
+  USING (false);
+
+COMMIT;


### PR DESCRIPTION

## Summary

- Add docs/PII.md: field-level PII classification (P0-P3) across all tables with handling rules and retention policy
- Add docs/GDPR.md: data export/deletion plan, anonymisation strategy, breach notification runbook, data minimisation principles
- Add 007_audit_log_append_only.sql: trigger-based UPDATE/DELETE block + RLS deny policies on audit_log
- Add docs/BACKUP_RESTORE.md: pg_dump/pg_restore procedures, post-restore validation queries, DR runbook with SLAs
