### PR TITLE
[17] test: API contract tests, webhook replay fixtures, Playwright E2…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
 
 # next.js
 /.next/

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E smoke tests — verify critical pages load and render key elements.
+ * These run against a local dev server or CI deployment.
+ */
+
+test.describe('Smoke tests — page loads', () => {
+  test('homepage loads and shows hero section', async ({ page }) => {
+    await page.goto('/');
+    // Should redirect to /tr or /en based on locale
+    await expect(page).toHaveURL(/\/(tr|en)/);
+    // Page should have the brand or hero content
+    await expect(page.locator('body')).toBeVisible();
+    // Title should be set
+    const title = await page.title();
+    expect(title.length).toBeGreaterThan(0);
+  });
+
+  test('products page loads and shows product grid', async ({ page }) => {
+    await page.goto('/en/products');
+    await expect(page).toHaveURL(/\/en\/products/);
+    // Should have at least one product card
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('stores page loads', async ({ page }) => {
+    await page.goto('/en/stores');
+    await expect(page).toHaveURL(/\/en\/stores/);
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('cart page loads (empty cart)', async ({ page }) => {
+    await page.goto('/en/cart');
+    await expect(page).toHaveURL(/\/en\/cart/);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('login page loads with form', async ({ page }) => {
+    await page.goto('/en/login');
+    await expect(page).toHaveURL(/\/en\/login/);
+    // Should show email input
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    // Should show password input
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+  });
+
+  test('register page loads with form', async ({ page }) => {
+    await page.goto('/en/register');
+    await expect(page).toHaveURL(/\/en\/register/);
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+  });
+});
+
+test.describe('Smoke tests — navigation', () => {
+  test('header navigation links work', async ({ page }) => {
+    await page.goto('/en');
+    // Click products link if visible in header
+    const productsLink = page.locator('header a[href*="products"]').first();
+    if (await productsLink.isVisible()) {
+      await productsLink.click();
+      await expect(page).toHaveURL(/\/en\/products/);
+    }
+  });
+
+  test('locale switching works', async ({ page }) => {
+    await page.goto('/en');
+    // Look for TR/Turkish locale switch
+    const localeLink = page.locator('a[href*="/tr"], button:has-text("TR")').first();
+    if (await localeLink.isVisible()) {
+      await localeLink.click();
+      await expect(page).toHaveURL(/\/tr/);
+    }
+  });
+});
+
+test.describe('Smoke tests — login flow', () => {
+  test('login form validates empty submission', async ({ page }) => {
+    await page.goto('/en/login');
+    // Try to submit empty form
+    const submitBtn = page.locator('button[type="submit"]').first();
+    if (await submitBtn.isVisible()) {
+      await submitBtn.click();
+      // Should stay on login page (validation prevents navigation)
+      await expect(page).toHaveURL(/\/en\/login/);
+    }
+  });
+
+  test('login form accepts email input', async ({ page }) => {
+    await page.goto('/en/login');
+    const emailInput = page.locator('input[type="email"]');
+    await emailInput.fill('test@example.com');
+    await expect(emailInput).toHaveValue('test@example.com');
+  });
+});
+
+test.describe('Smoke tests — products flow', () => {
+  test('product search filters results', async ({ page }) => {
+    await page.goto('/en/products');
+    const searchInput = page.locator('input[type="text"]').first();
+    if (await searchInput.isVisible()) {
+      await searchInput.fill('chocolate');
+      // Wait for debounce
+      await page.waitForTimeout(500);
+      // Page should still be visible with filtered results
+      await expect(page.locator('body')).toBeVisible();
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^16.1.6",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2371,6 +2372,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -8698,6 +8715,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "analyze": "cross-env ANALYZE=true next build"
+    "analyze": "cross-env ANALYZE=true next build",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -40,6 +42,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.1.6",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for E2E smoke tests.
+ *
+ * Usage:
+ *   npx playwright test              # run all E2E tests
+ *   npx playwright test --headed     # run with visible browser
+ *   npx playwright show-report       # view HTML report
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Start the dev server before tests if not in CI */
+  webServer: process.env.CI
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        timeout: 60_000,
+      },
+});

--- a/tests/api/handler-contract.test.ts
+++ b/tests/api/handler-contract.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { withHandler } from '@/lib/api-handler';
+import { ApiError } from '@/lib/api-error';
+
+/**
+ * Contract tests for the withHandler HOF.
+ *
+ * Validates the standardised response contract:
+ *  - Success → original response + x-request-id header
+ *  - ApiError → { code, message, requestId } with correct status
+ *  - Unknown error → 500 with INTERNAL_ERROR code
+ */
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/test', { headers });
+}
+
+describe('withHandler — response contract', () => {
+  // ── Success path ───────────────────────────────────────────
+
+  it('passes requestId to handler and attaches x-request-id header', async () => {
+    const handler = withHandler(async (_req, { requestId }) => {
+      return NextResponse.json({ ok: true, requestId });
+    });
+
+    const res = await handler(makeRequest({ 'x-request-id': 'test-rid-123' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-request-id')).toBe('test-rid-123');
+    expect(body.requestId).toBe('test-rid-123');
+  });
+
+  it('generates a UUID requestId when header is missing', async () => {
+    const handler = withHandler(async (_req, { requestId }) => {
+      return NextResponse.json({ requestId });
+    });
+
+    const res = await handler(makeRequest());
+    const rid = res.headers.get('x-request-id');
+
+    expect(rid).toBeTruthy();
+    // UUID v4 format: 8-4-4-4-12
+    expect(rid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  // ── ApiError path ──────────────────────────────────────────
+
+  it('converts ApiError to { code, message, requestId } JSON', async () => {
+    const handler = withHandler(async () => {
+      throw new ApiError('E_TEST_ERROR', 'Something went wrong', 422);
+    });
+
+    const res = await handler(makeRequest({ 'x-request-id': 'rid-err' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body).toEqual({
+      code: 'E_TEST_ERROR',
+      message: 'Something went wrong',
+      requestId: 'rid-err',
+    });
+    expect(res.headers.get('x-request-id')).toBe('rid-err');
+  });
+
+  it('uses default 500 status when ApiError has no explicit status', async () => {
+    const handler = withHandler(async () => {
+      throw new ApiError('E_DB_FAIL', 'DB down');
+    });
+
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe('E_DB_FAIL');
+  });
+
+  // ── Unknown error path ─────────────────────────────────────
+
+  it('catches unknown errors and returns INTERNAL_ERROR 500', async () => {
+    const handler = withHandler(async () => {
+      throw new Error('unexpected crash');
+    });
+
+    const res = await handler(makeRequest({ 'x-request-id': 'rid-crash' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.code).toBe('INTERNAL_ERROR');
+    expect(body.message).toBe('An unexpected error occurred');
+    expect(body.requestId).toBe('rid-crash');
+    expect(res.headers.get('x-request-id')).toBe('rid-crash');
+  });
+
+  it('catches non-Error throws (string, object)', async () => {
+    const handler = withHandler(async () => {
+      throw 'string error';
+    });
+
+    const res = await handler(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.code).toBe('INTERNAL_ERROR');
+  });
+
+  // ── Header propagation ─────────────────────────────────────
+
+  it('preserves custom headers set by the handler', async () => {
+    const handler = withHandler(async () => {
+      return NextResponse.json({ ok: true }, {
+        headers: { 'X-Custom': 'value' },
+      });
+    });
+
+    const res = await handler(makeRequest());
+    expect(res.headers.get('x-custom')).toBe('value');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+  });
+});

--- a/tests/api/products.test.ts
+++ b/tests/api/products.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { sampleProducts } from '@/lib/data';
+
+/**
+ * Contract tests for GET /api/products
+ *
+ * These test the route handler directly (no HTTP server needed).
+ * We import the handler function and invoke it with a Request object.
+ */
+
+// Dynamic import so vitest can resolve the edge-runtime exports
+async function callProducts(params: Record<string, string> = {}) {
+  const { GET } = await import('@/app/api/products/route');
+  const url = new URL('http://localhost/api/products');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const res = await GET(new Request(url.toString()));
+  const body = await res.json();
+  return { status: res.status, headers: res.headers, body };
+}
+
+describe('GET /api/products — contract', () => {
+  // ── Response shape ──────────────────────────────────────────
+
+  it('returns { products: array, total: number }', async () => {
+    const { status, body } = await callProducts();
+    expect(status).toBe(200);
+    expect(body).toHaveProperty('products');
+    expect(body).toHaveProperty('total');
+    expect(Array.isArray(body.products)).toBe(true);
+    expect(typeof body.total).toBe('number');
+  });
+
+  it('each product has required fields', async () => {
+    const { body } = await callProducts();
+    for (const p of body.products) {
+      expect(p).toHaveProperty('id');
+      expect(p).toHaveProperty('slug');
+      expect(p).toHaveProperty('name_en');
+      expect(p).toHaveProperty('name_tr');
+      expect(p).toHaveProperty('price');
+      expect(p).toHaveProperty('category');
+      expect(p).toHaveProperty('image_url');
+    }
+  });
+
+  // ── Cache headers ───────────────────────────────────────────
+
+  it('sets Cache-Control with s-maxage', async () => {
+    const { headers } = await callProducts();
+    const cc = headers.get('cache-control');
+    expect(cc).toContain('s-maxage=300');
+    expect(cc).toContain('stale-while-revalidate=600');
+  });
+
+  // ── Filtering ───────────────────────────────────────────────
+
+  it('filters by category', async () => {
+    const { body } = await callProducts({ category: 'beverage' });
+    expect(body.products.length).toBeGreaterThan(0);
+    for (const p of body.products) {
+      expect(p.category).toBe('beverage');
+    }
+  });
+
+  it('returns all when category=all', async () => {
+    const { body } = await callProducts({ category: 'all' });
+    expect(body.total).toBe(sampleProducts.length);
+  });
+
+  it('filters featured products', async () => {
+    const { body } = await callProducts({ featured: 'true' });
+    expect(body.products.length).toBeGreaterThan(0);
+    for (const p of body.products) {
+      expect(p.featured).toBe(true);
+    }
+  });
+
+  it('limits results', async () => {
+    const { body } = await callProducts({ limit: '2' });
+    expect(body.products.length).toBeLessThanOrEqual(2);
+    expect(body.total).toBeLessThanOrEqual(2);
+  });
+
+  // ── Edge cases ──────────────────────────────────────────────
+
+  it('returns empty array for non-existent category', async () => {
+    const { body } = await callProducts({ category: 'nonexistent' });
+    expect(body.products).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it('ignores invalid limit gracefully', async () => {
+    const { body } = await callProducts({ limit: 'abc' });
+    // NaN parseInt → NaN, slice(0, NaN) returns []
+    expect(Array.isArray(body.products)).toBe(true);
+  });
+});

--- a/tests/api/stores.test.ts
+++ b/tests/api/stores.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Contract tests for GET /api/stores
+ *
+ * The route calls Supabase then falls back to demo data.
+ * We mock the Supabase module so the route always uses the demo fallback,
+ * letting us test the contract without a real database.
+ */
+
+// Mock getSupabasePublicEnv so createClient() in the route gets dummy values
+vi.mock('@/lib/supabase/env', () => ({
+  getSupabasePublicEnv: () => ({
+    url: 'https://fake.supabase.co',
+    anonKey: 'fake-key',
+  }),
+}));
+
+// Mock @supabase/supabase-js so no real HTTP calls are made.
+// The query chain returns an error, forcing the demo-data fallback.
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            eq: () =>
+              Promise.resolve({ data: null, error: new Error('mock') }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+async function callStores(params: Record<string, string> = {}) {
+  const { GET } = await import('@/app/api/stores/route');
+  const url = new URL('http://localhost/api/stores');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  const res = await GET(new Request(url.toString()));
+  const body = await res.json();
+  return { status: res.status, headers: res.headers, body };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/stores — contract', () => {
+  // ── Response shape ──────────────────────────────────────────
+
+  it('returns { stores: array, total: number }', async () => {
+    const { status, body } = await callStores();
+    expect(status).toBe(200);
+    expect(body).toHaveProperty('stores');
+    expect(body).toHaveProperty('total');
+    expect(Array.isArray(body.stores)).toBe(true);
+    expect(typeof body.total).toBe('number');
+  });
+
+  it('each store has required fields', async () => {
+    const { body } = await callStores();
+    for (const s of body.stores) {
+      expect(s).toHaveProperty('id');
+      expect(s).toHaveProperty('name');
+      expect(s).toHaveProperty('slug');
+      expect(s).toHaveProperty('address');
+      expect(s).toHaveProperty('city');
+      expect(s).toHaveProperty('latitude');
+      expect(s).toHaveProperty('longitude');
+      expect(s).toHaveProperty('is_active');
+    }
+  });
+
+  // ── Cache headers ───────────────────────────────────────────
+
+  it('sets Cache-Control with s-maxage=600', async () => {
+    const { headers } = await callStores();
+    const cc = headers.get('cache-control');
+    expect(cc).toContain('s-maxage=600');
+    expect(cc).toContain('stale-while-revalidate=1200');
+  });
+
+  // ── Locale-based demo data ─────────────────────────────────
+
+  it('returns Turkish demo stores by default', async () => {
+    const { body } = await callStores();
+    expect(body.stores.length).toBeGreaterThan(0);
+    // Turkish stores have İstanbul or Ankara
+    const cities = body.stores.map((s: { city: string }) => s.city);
+    expect(cities.some((c: string) => c === 'İstanbul' || c === 'Ankara')).toBe(true);
+  });
+
+  it('returns English demo stores for locale=en', async () => {
+    const { body } = await callStores({ locale: 'en' });
+    expect(body.stores.length).toBeGreaterThan(0);
+    const cities = body.stores.map((s: { city: string }) => s.city);
+    expect(cities.some((c: string) => c === 'New York' || c === 'London')).toBe(true);
+  });
+
+  // ── City filter ─────────────────────────────────────────────
+
+  it('filters by city', async () => {
+    const { body } = await callStores({ city: 'İstanbul' });
+    for (const s of body.stores) {
+      expect(s.city).toBe('İstanbul');
+    }
+  });
+
+  it('returns empty for non-existent city', async () => {
+    const { body } = await callStores({ city: 'Nonexistent' });
+    expect(body.stores).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+});

--- a/tests/api/webhook-replay.test.ts
+++ b/tests/api/webhook-replay.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import checkoutCompleted from '@/tests/fixtures/stripe-checkout-completed.json';
+import checkoutExpired from '@/tests/fixtures/stripe-checkout-expired.json';
+import paymentFailed from '@/tests/fixtures/stripe-payment-failed.json';
+
+/**
+ * Webhook replay tests using Stripe fixture payloads.
+ *
+ * Strategy:
+ *  - Mock getStripe().webhooks.constructEvent to bypass signature verification
+ *    and return the fixture payload directly.
+ *  - Mock Supabase admin client for DB calls.
+ *  - Mock env/config for required secrets.
+ *  - Test response shapes, idempotency, maintenance mode, and error paths.
+ */
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+const mockRpc = vi.fn().mockResolvedValue({ data: { success: true, order_id: 'oid', points_awarded: 10 }, error: null });
+const mockUpdate = vi.fn().mockReturnValue({
+  eq: vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  }),
+});
+const mockInsert = vi.fn();
+
+const mockSupabase = {
+  from: vi.fn((table: string) => {
+    if (table === 'stripe_events') return { insert: mockInsert };
+    if (table === 'orders') return { update: mockUpdate };
+    return {};
+  }),
+  rpc: mockRpc,
+};
+
+// Mock Supabase createClient
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => mockSupabase,
+}));
+
+// Mock env
+vi.mock('@/lib/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://fake.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'fake-service-role',
+    STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
+  },
+}));
+
+// Mock config with feature flags
+let webhooksEnabled = true;
+vi.mock('@/lib/config', () => ({
+  featureFlags: {
+    get webhooksEnabled() { return webhooksEnabled; },
+    checkoutEnabled: true,
+  },
+}));
+
+// Mock getStripe — constructEvent returns the fixture directly
+let constructEventResult: unknown = null;
+let constructEventThrow: Error | null = null;
+
+vi.mock('@/lib/stripe/server', () => ({
+  getStripe: () => ({
+    webhooks: {
+      constructEvent: () => {
+        if (constructEventThrow) throw constructEventThrow;
+        return constructEventResult;
+      },
+    },
+  }),
+}));
+
+// Mock withTimeout to just execute the promise
+vi.mock('@/lib/fetch-with-timeout', () => ({
+  withTimeout: (promise: Promise<unknown>) => promise,
+}));
+
+// Suppress logger output in tests
+vi.mock('@/lib/logger', () => {
+  const noop = () => {};
+  const noopLogger = {
+    info: noop, warn: noop, error: noop, debug: noop,
+    metric: noop, count: noop,
+    withContext: () => noopLogger,
+  };
+  return { logger: noopLogger, startTimer: () => () => 0 };
+});
+
+// ── Helpers ───────────────────────────────────────────────────
+
+async function callWebhook(body: string, headers: Record<string, string> = {}) {
+  // Reset module cache so fresh mock state is picked up
+  const mod = await import('@/app/api/webhooks/stripe/route');
+  const req = new NextRequest('http://localhost/api/webhooks/stripe', {
+    method: 'POST',
+    body,
+    headers: {
+      'stripe-signature': 'sig_test',
+      'x-request-id': 'rid-webhook-test',
+      ...headers,
+    },
+  });
+  const res = await mod.POST(req);
+  const json = await res.json();
+  return { status: res.status, body: json, headers: res.headers };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  webhooksEnabled = true;
+  constructEventResult = null;
+  constructEventThrow = null;
+  // Default: first insert succeeds (new event)
+  mockInsert.mockResolvedValue({ error: null });
+});
+
+describe('POST /api/webhooks/stripe — replay tests', () => {
+  // ── Response contract ──────────────────────────────────────
+
+  it('returns { received: true } + x-request-id for valid event', async () => {
+    constructEventResult = checkoutCompleted;
+    const { status, body, headers } = await callWebhook(JSON.stringify(checkoutCompleted));
+
+    expect(status).toBe(200);
+    expect(body.received).toBe(true);
+    expect(headers.get('x-request-id')).toBe('rid-webhook-test');
+  });
+
+  // ── Maintenance mode ───────────────────────────────────────
+
+  it('returns 503 MAINTENANCE when webhooks disabled', async () => {
+    webhooksEnabled = false;
+    const { status, body } = await callWebhook('{}');
+
+    expect(status).toBe(503);
+    expect(body.code).toBe('MAINTENANCE');
+    expect(body).toHaveProperty('requestId');
+  });
+
+  // ── Missing signature ──────────────────────────────────────
+
+  it('returns 400 when stripe-signature header is missing', async () => {
+    const mod = await import('@/app/api/webhooks/stripe/route');
+    const req = new NextRequest('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-request-id': 'rid-nosig' },
+      // No stripe-signature header
+    });
+    const res = await mod.POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe('E_WEBHOOK_SIGNATURE_MISSING');
+    expect(body).toHaveProperty('requestId');
+  });
+
+  // ── Invalid signature ──────────────────────────────────────
+
+  it('returns 400 when signature verification fails', async () => {
+    constructEventThrow = new Error('Invalid signature');
+    const { status, body } = await callWebhook('{}');
+
+    expect(status).toBe(400);
+    expect(body.code).toBe('E_WEBHOOK_SIGNATURE_INVALID');
+  });
+
+  // ── Idempotency: duplicate event ───────────────────────────
+
+  it('returns 200 { received: true } for duplicate event (idempotent)', async () => {
+    constructEventResult = checkoutCompleted;
+    // Simulate unique_violation (PG code 23505)
+    mockInsert.mockResolvedValue({ error: { code: '23505', message: 'duplicate' } });
+
+    const { status, body } = await callWebhook(JSON.stringify(checkoutCompleted));
+
+    expect(status).toBe(200);
+    expect(body.received).toBe(true);
+  });
+
+  // ── Event: checkout.session.completed ──────────────────────
+
+  it('processes checkout.session.completed via RPC', async () => {
+    constructEventResult = checkoutCompleted;
+    const { status } = await callWebhook(JSON.stringify(checkoutCompleted));
+
+    expect(status).toBe(200);
+    expect(mockRpc).toHaveBeenCalledWith('process_payment_completed', {
+      p_stripe_session_id: 'cs_test_a1b2c3d4e5',
+      p_payment_intent_id: 'pi_test_intent_001',
+    });
+  });
+
+  // ── Event: checkout.session.expired ────────────────────────
+
+  it('processes checkout.session.expired', async () => {
+    constructEventResult = checkoutExpired;
+    const { status } = await callWebhook(JSON.stringify(checkoutExpired));
+
+    expect(status).toBe(200);
+    expect(mockSupabase.from).toHaveBeenCalledWith('orders');
+  });
+
+  // ── Event: payment_intent.payment_failed ───────────────────
+
+  it('processes payment_intent.payment_failed (log only)', async () => {
+    constructEventResult = paymentFailed;
+    const { status, body } = await callWebhook(JSON.stringify(paymentFailed));
+
+    expect(status).toBe(200);
+    expect(body.received).toBe(true);
+  });
+
+  // ── Handler error → 500 ────────────────────────────────────
+
+  it('returns 500 E_WEBHOOK_HANDLER_ERROR when handler throws', async () => {
+    constructEventResult = checkoutCompleted;
+    mockRpc.mockRejectedValue(new Error('DB crash'));
+
+    const { status, body } = await callWebhook(JSON.stringify(checkoutCompleted));
+
+    expect(status).toBe(500);
+    expect(body.code).toBe('E_WEBHOOK_HANDLER_ERROR');
+    expect(body.message).toBe('Internal error');
+  });
+
+  // ── Unhandled event type → 200 ─────────────────────────────
+
+  it('returns 200 for unknown event types (unhandled)', async () => {
+    constructEventResult = {
+      id: 'evt_unknown_001',
+      type: 'customer.subscription.created',
+      data: { object: {} },
+    };
+    const { status, body } = await callWebhook('{}');
+
+    expect(status).toBe(200);
+    expect(body.received).toBe(true);
+  });
+});

--- a/tests/fixtures/stripe-checkout-completed.json
+++ b/tests/fixtures/stripe-checkout-completed.json
@@ -1,0 +1,24 @@
+{
+  "id": "evt_test_checkout_completed_001",
+  "object": "event",
+  "type": "checkout.session.completed",
+  "data": {
+    "object": {
+      "id": "cs_test_a1b2c3d4e5",
+      "object": "checkout.session",
+      "payment_intent": "pi_test_intent_001",
+      "payment_status": "paid",
+      "status": "complete",
+      "customer_email": "test@example.com",
+      "amount_total": 15000,
+      "currency": "try",
+      "metadata": {
+        "orderId": "order-uuid-001"
+      }
+    }
+  },
+  "created": 1708300000,
+  "livemode": false,
+  "pending_webhooks": 1,
+  "api_version": "2024-12-18.acacia"
+}

--- a/tests/fixtures/stripe-checkout-expired.json
+++ b/tests/fixtures/stripe-checkout-expired.json
@@ -1,0 +1,24 @@
+{
+  "id": "evt_test_checkout_expired_001",
+  "object": "event",
+  "type": "checkout.session.expired",
+  "data": {
+    "object": {
+      "id": "cs_test_expired_x1y2z3",
+      "object": "checkout.session",
+      "payment_intent": null,
+      "payment_status": "unpaid",
+      "status": "expired",
+      "customer_email": "expired@example.com",
+      "amount_total": 9000,
+      "currency": "try",
+      "metadata": {
+        "orderId": "order-uuid-002"
+      }
+    }
+  },
+  "created": 1708300100,
+  "livemode": false,
+  "pending_webhooks": 1,
+  "api_version": "2024-12-18.acacia"
+}

--- a/tests/fixtures/stripe-payment-failed.json
+++ b/tests/fixtures/stripe-payment-failed.json
@@ -1,0 +1,23 @@
+{
+  "id": "evt_test_payment_failed_001",
+  "object": "event",
+  "type": "payment_intent.payment_failed",
+  "data": {
+    "object": {
+      "id": "pi_test_failed_001",
+      "object": "payment_intent",
+      "amount": 5000,
+      "currency": "try",
+      "status": "requires_payment_method",
+      "last_payment_error": {
+        "message": "Your card was declined.",
+        "type": "card_error",
+        "code": "card_declined"
+      }
+    }
+  },
+  "created": 1708300200,
+  "livemode": false,
+  "pending_webhooks": 1,
+  "api_version": "2024-12-18.acacia"
+}


### PR DESCRIPTION
## Summary

- Add tests/api/products.test.ts: 9 contract tests for GET /api/products (shape, cache headers, filters, edge cases)
- Add tests/api/stores.test.ts: 7 contract tests for GET /api/stores (shape, cache headers, locale, city filter)
- Add tests/api/handler-contract.test.ts: 7 tests for withHandler HOF (requestId propagation, ApiError → JSON, unknown error → 500)
- Add tests/api/webhook-replay.test.ts: 10 tests replaying Stripe fixture payloads (idempotency, signature validation, maintenance mode, event routing, error paths)
- Add tests/fixtures/stripe-*.json: 3 Stripe webhook event fixtures (checkout.completed, checkout.expired, payment_failed)
- Add playwright.config.ts + e2e/smoke.spec.ts: 10 Playwright E2E smoke tests (page loads, navigation, login form, product search)
- Add npm scripts: test:e2e, test:e2e:headed
- Update .gitignore: exclude playwright artifacts (test-results, playwright-report, blob-report)
- Total: 125 vitest tests passing (33 new), 0 type errors, 0 lint errors



