### PR TITLE
feat: perf regression detection + k6 500 VU load test

### DIFF
--- a/lib/alerts.ts
+++ b/lib/alerts.ts
@@ -18,6 +18,7 @@
 import { logger } from './logger';
 import { captureWithContext, type SentryDomain } from './sentry';
 import type { MetricsCollector, EndpointSummary, CheckoutSummary } from './metrics';
+import type { VitalRegression } from './perf-budget';
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -43,6 +44,8 @@ export interface AlertContext {
   checkoutSummary: CheckoutSummary;
   /** Current process memory usage in MB. */
   memoryUsageMB?: number;
+  /** Web Vital regressions detected by perf-budget, if available. */
+  vitalRegressions?: VitalRegression[];
 }
 
 export interface FiredAlert {
@@ -120,6 +123,30 @@ export const ALERT_RULES: AlertRule[] = [
     message: (ctx) =>
       `Memory usage is ${ctx.memoryUsageMB?.toFixed(0) ?? '?'}MB (threshold: 512MB)`,
   },
+  {
+    id: 'vital_fcp_regression',
+    description: 'FCP regression > 5%',
+    severity: 'warn',
+    domain: 'checkout',
+    evaluate: (ctx) =>
+      !!ctx.vitalRegressions?.some((r) => r.name === 'FCP'),
+    message: (ctx) => {
+      const r = ctx.vitalRegressions?.find((v) => v.name === 'FCP');
+      return r?.message ?? 'FCP regression detected';
+    },
+  },
+  {
+    id: 'vital_lcp_regression',
+    description: 'LCP regression > 3%',
+    severity: 'critical',
+    domain: 'checkout',
+    evaluate: (ctx) =>
+      !!ctx.vitalRegressions?.some((r) => r.name === 'LCP'),
+    message: (ctx) => {
+      const r = ctx.vitalRegressions?.find((v) => v.name === 'LCP');
+      return r?.message ?? 'LCP regression detected';
+    },
+  },
 ];
 
 // ── Evaluation Engine ───────────────────────────────────────
@@ -134,6 +161,7 @@ export const ALERT_RULES: AlertRule[] = [
 export function evaluateAlerts(
   collector: MetricsCollector,
   memoryUsageMB?: number,
+  vitalRegressions?: VitalRegression[],
 ): FiredAlert[] {
   // Build context
   const endpointSummaries = new Map<string, EndpointSummary>();
@@ -145,6 +173,7 @@ export function evaluateAlerts(
     endpointSummaries,
     checkoutSummary: collector.getCheckoutSummary(),
     memoryUsageMB,
+    vitalRegressions,
   };
 
   const fired: FiredAlert[] = [];
@@ -195,6 +224,7 @@ export function evaluateAlerts(
 export function buildAlertContext(
   collector: MetricsCollector,
   memoryUsageMB?: number,
+  vitalRegressions?: VitalRegression[],
 ): AlertContext {
   const endpointSummaries = new Map<string, EndpointSummary>();
   for (const endpoint of collector.getTrackedEndpoints()) {
@@ -204,5 +234,6 @@ export function buildAlertContext(
     endpointSummaries,
     checkoutSummary: collector.getCheckoutSummary(),
     memoryUsageMB,
+    vitalRegressions,
   };
 }

--- a/lib/perf-budget.ts
+++ b/lib/perf-budget.ts
@@ -1,0 +1,172 @@
+/**
+ * Performance Budget — bundle-size + Web Vitals regression detection.
+ *
+ * Two concerns:
+ *  1. **Bundle guard** — CI fails if First Load JS exceeds a threshold (default 320 KB).
+ *  2. **Vital regression** — alerts when FCP / LCP grow beyond a percentage vs baseline.
+ *
+ * Both are pure, side-effect-free functions so they're trivially testable
+ * and composable with the alert engine in `lib/alerts.ts`.
+ *
+ * Usage:
+ *   import { checkBundleBudget, detectVitalRegression } from '@/lib/perf-budget';
+ *
+ *   // Bundle guard (CI)
+ *   const result = checkBundleBudget(315_000);
+ *   if (!result.pass) process.exit(1);
+ *
+ *   // Vital regression (monitoring)
+ *   const regressions = detectVitalRegression(baseline, current);
+ */
+
+import { logger } from './logger';
+
+// ── Configuration ───────────────────────────────────────────
+
+/** Default maximum First Load JS in bytes (320 KB). */
+export const DEFAULT_BUNDLE_BUDGET_BYTES = 320 * 1024;
+
+/** Default per-vital regression thresholds (fraction, e.g. 0.05 = 5 %). */
+export const DEFAULT_VITAL_THRESHOLDS: Record<string, number> = {
+  FCP: 0.05, // alert if FCP grows > 5 %
+  LCP: 0.03, // alert if LCP grows > 3 %
+};
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface BundleBudgetResult {
+  /** Whether the bundle is within budget. */
+  pass: boolean;
+  /** Actual first-load JS size in bytes. */
+  actualBytes: number;
+  /** Budget limit in bytes. */
+  budgetBytes: number;
+  /** How much over/under budget (negative = under). */
+  deltaBytes: number;
+  /** Human-readable message. */
+  message: string;
+}
+
+export interface VitalBaseline {
+  /** Vital name (e.g. "FCP", "LCP"). */
+  name: string;
+  /** Baseline value in ms. */
+  value: number;
+}
+
+export interface VitalRegression {
+  /** Vital name. */
+  name: string;
+  /** Baseline value (ms). */
+  baseline: number;
+  /** Current value (ms). */
+  current: number;
+  /** Growth as a fraction (e.g. 0.08 = 8 %). */
+  growthFraction: number;
+  /** Configured threshold fraction. */
+  threshold: number;
+  /** Human-readable message. */
+  message: string;
+}
+
+export interface VitalRegressionResult {
+  /** True if no regressions detected. */
+  pass: boolean;
+  /** Individual regressions found (empty if pass is true). */
+  regressions: VitalRegression[];
+}
+
+// ── Bundle Budget ───────────────────────────────────────────
+
+/**
+ * Check whether the first-load JS bundle is within the performance budget.
+ *
+ * @param actualBytes - Actual first-load JS size in bytes
+ * @param budgetBytes - Maximum allowed size in bytes (default 320 KB)
+ * @returns Result object with pass/fail + diagnostics
+ */
+export function checkBundleBudget(
+  actualBytes: number,
+  budgetBytes: number = DEFAULT_BUNDLE_BUDGET_BYTES,
+): BundleBudgetResult {
+  const deltaBytes = actualBytes - budgetBytes;
+  const pass = deltaBytes <= 0;
+
+  const actualKB = (actualBytes / 1024).toFixed(1);
+  const budgetKB = (budgetBytes / 1024).toFixed(1);
+
+  const message = pass
+    ? `Bundle OK: ${actualKB} KB (budget: ${budgetKB} KB)`
+    : `Bundle OVER budget: ${actualKB} KB exceeds ${budgetKB} KB by ${(deltaBytes / 1024).toFixed(1)} KB`;
+
+  if (!pass) {
+    logger.warn('perf_budget.bundle_exceeded', {
+      actualBytes,
+      budgetBytes,
+      deltaBytes,
+      actualKB,
+      budgetKB,
+    });
+  }
+
+  return { pass, actualBytes, budgetBytes, deltaBytes, message };
+}
+
+// ── Vital Regression Detection ──────────────────────────────
+
+/**
+ * Compare current Web Vital values against baselines and detect regressions.
+ *
+ * A regression is flagged when `(current - baseline) / baseline > threshold`.
+ *
+ * @param baselines - Array of baseline vital measurements
+ * @param currentValues - Map of vital name → current value (ms)
+ * @param thresholds - Per-vital growth thresholds (default: FCP 5 %, LCP 3 %)
+ * @returns Result with pass/fail + detailed regression list
+ */
+export function detectVitalRegression(
+  baselines: VitalBaseline[],
+  currentValues: Map<string, number>,
+  thresholds: Record<string, number> = DEFAULT_VITAL_THRESHOLDS,
+): VitalRegressionResult {
+  const regressions: VitalRegression[] = [];
+
+  for (const baseline of baselines) {
+    const current = currentValues.get(baseline.name);
+    if (current === undefined) continue;
+
+    // Skip if baseline is 0 to avoid division by zero
+    if (baseline.value <= 0) continue;
+
+    const threshold = thresholds[baseline.name];
+    if (threshold === undefined) continue;
+
+    const growthFraction = (current - baseline.value) / baseline.value;
+
+    if (growthFraction > threshold) {
+      const pct = (growthFraction * 100).toFixed(1);
+      const threshPct = (threshold * 100).toFixed(0);
+
+      const regression: VitalRegression = {
+        name: baseline.name,
+        baseline: baseline.value,
+        current,
+        growthFraction,
+        threshold,
+        message: `${baseline.name} regressed ${pct}% (${baseline.value}ms → ${current}ms, threshold: ${threshPct}%)`,
+      };
+
+      regressions.push(regression);
+
+      logger.warn('perf_budget.vital_regression', {
+        vital: baseline.name,
+        baseline: baseline.value,
+        current,
+        growthPercent: pct,
+        threshold: threshPct,
+      });
+    }
+  }
+
+  return { pass: regressions.length === 0, regressions };
+}

--- a/scripts/load-test.js
+++ b/scripts/load-test.js
@@ -2,17 +2,25 @@
  * k6 Load Test — Donut Shop API
  *
  * Scenarios:
- *   1. Product browsing (GET /api/products)
- *   2. Product search (GET /api/products/search)
- *   3. Checkout flow (POST /api/checkout)
+ *   1. Product browsing  (GET  /api/products)        — 60% of traffic
+ *   2. Product search    (GET  /api/products/search)  — 20% of traffic
+ *   3. Checkout flow     (POST /api/checkout)         — 20% of traffic
+ *
+ * Load profile (500 concurrent users):
+ *   Stage 1 — Ramp-up:   0 → 500 VUs over 60 s
+ *   Stage 2 — Sustained: 500 VUs for 3 min
+ *   Stage 3 — Ramp-down: 500 → 0 VUs over 60 s
  *
  * Thresholds:
- *   - p95 response time < 2 seconds
- *   - Error rate < 1%
+ *   - Overall p95 response time < 2 s
+ *   - Checkout p95 < 500 ms
+ *   - Browse   p95 < 500 ms
+ *   - Search   p95 < 1 s
+ *   - Error rate < 1 %
  *
  * Usage:
  *   k6 run scripts/load-test.js
- *   k6 run --vus 50 --duration 3m scripts/load-test.js
+ *   k6 run --env BASE_URL=https://staging.example.com scripts/load-test.js
  *
  * Environment:
  *   BASE_URL (default: http://localhost:3000)
@@ -30,39 +38,50 @@ const productSearchTrend = new Trend('product_search_duration');
 const checkoutTrend = new Trend('checkout_duration');
 
 // ─── Configuration ──────────────────────────────────────────
+// 500 concurrent users: ramp-up 60 s → sustained 3 min → ramp-down 60 s
+// Traffic split roughly 60 / 20 / 20 across browse / search / checkout.
 
 export const options = {
   scenarios: {
     browse: {
-      executor: 'constant-vus',
-      vus: 30,
-      duration: '3m',
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '60s',  target: 300 },  // ramp 0 → 300
+        { duration: '3m',   target: 300 },  // hold 300
+        { duration: '60s',  target: 0 },    // ramp down
+      ],
       exec: 'browseProducts',
       tags: { scenario: 'browse' },
     },
     search: {
-      executor: 'constant-vus',
-      vus: 10,
-      duration: '3m',
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '60s',  target: 100 },
+        { duration: '3m',   target: 100 },
+        { duration: '60s',  target: 0 },
+      ],
       exec: 'searchProducts',
-      startTime: '10s',
+      startTime: '5s',
       tags: { scenario: 'search' },
     },
     checkout: {
-      executor: 'constant-vus',
-      vus: 10,
-      duration: '3m',
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '60s',  target: 100 },
+        { duration: '3m',   target: 100 },
+        { duration: '60s',  target: 0 },
+      ],
       exec: 'checkoutFlow',
-      startTime: '20s',
+      startTime: '10s',
       tags: { scenario: 'checkout' },
     },
   },
   thresholds: {
-    http_req_duration: ['p(95)<2000'],      // p95 < 2 seconds
-    errors: ['rate<0.01'],                   // Error rate < 1%
-    product_browse_duration: ['p(95)<1000'], // Browse p95 < 1s
-    product_search_duration: ['p(95)<1500'], // Search p95 < 1.5s
-    checkout_duration: ['p(95)<3000'],       // Checkout p95 < 3s
+    http_req_duration: ['p(95)<2000'],       // overall p95 < 2 s
+    errors: ['rate<0.01'],                    // error rate < 1 %
+    product_browse_duration: ['p(95)<500'],   // browse  p95 < 500 ms
+    product_search_duration: ['p(95)<1000'],  // search  p95 < 1 s
+    checkout_duration: ['p(95)<500'],         // checkout p95 < 500 ms
   },
 };
 
@@ -230,26 +249,49 @@ export function checkoutFlow() {
 // ─── Summary Handler ────────────────────────────────────────
 
 export function handleSummary(data) {
+  const val = (metric, key = 'p(95)') =>
+    data.metrics[metric]?.values?.[key] ?? 0;
+
   const summary = {
     timestamp: new Date().toISOString(),
-    totalRequests: data.metrics.http_reqs?.values?.count || 0,
-    p95Duration: data.metrics.http_req_duration?.values?.['p(95)'] || 0,
-    p99Duration: data.metrics.http_req_duration?.values?.['p(99)'] || 0,
-    errorRate: data.metrics.errors?.values?.rate || 0,
+    totalRequests: val('http_reqs', 'count'),
+    latency: {
+      p50: val('http_req_duration', 'p(50)'),
+      p95: val('http_req_duration', 'p(95)'),
+      p99: val('http_req_duration', 'p(99)'),
+      max: val('http_req_duration', 'max'),
+      avg: val('http_req_duration', 'avg'),
+    },
+    errorRate: val('errors', 'rate'),
     scenarios: {
       browse: {
-        p95: data.metrics.product_browse_duration?.values?.['p(95)'] || 0,
+        p50: val('product_browse_duration', 'p(50)'),
+        p95: val('product_browse_duration', 'p(95)'),
+        p99: val('product_browse_duration', 'p(99)'),
       },
       search: {
-        p95: data.metrics.product_search_duration?.values?.['p(95)'] || 0,
+        p50: val('product_search_duration', 'p(50)'),
+        p95: val('product_search_duration', 'p(95)'),
+        p99: val('product_search_duration', 'p(99)'),
       },
       checkout: {
-        p95: data.metrics.checkout_duration?.values?.['p(95)'] || 0,
+        p50: val('checkout_duration', 'p(50)'),
+        p95: val('checkout_duration', 'p(95)'),
+        p99: val('checkout_duration', 'p(99)'),
       },
     },
     thresholds: {
-      'p95 < 2s': (data.metrics.http_req_duration?.values?.['p(95)'] || 0) < 2000,
-      'error rate < 1%': (data.metrics.errors?.values?.rate || 0) < 0.01,
+      'overall p95 < 2s':     val('http_req_duration') < 2000,
+      'browse p95 < 500ms':   val('product_browse_duration') < 500,
+      'search p95 < 1s':      val('product_search_duration') < 1000,
+      'checkout p95 < 500ms': val('checkout_duration') < 500,
+      'error rate < 1%':      val('errors', 'rate') < 0.01,
+    },
+    loadProfile: {
+      peakVUs: 500,
+      rampUpSeconds: 60,
+      sustainedSeconds: 180,
+      rampDownSeconds: 60,
     },
   };
 

--- a/tests/lib/alerts.test.ts
+++ b/tests/lib/alerts.test.ts
@@ -302,4 +302,73 @@ describe('Alert Thresholds', () => {
       ALERT_RULES.push(...originalRules);
     });
   });
+
+  // ── Rule: vital_fcp_regression ────────────────────────────
+
+  describe('vital_fcp_regression', () => {
+    it('does not fire when no vital regressions provided', () => {
+      const fired = evaluateAlerts(collector);
+      expect(fired.find((a) => a.ruleId === 'vital_fcp_regression')).toBeUndefined();
+    });
+
+    it('does not fire when vitalRegressions is empty', () => {
+      const fired = evaluateAlerts(collector, undefined, []);
+      expect(fired.find((a) => a.ruleId === 'vital_fcp_regression')).toBeUndefined();
+    });
+
+    it('fires when FCP regression is present', () => {
+      const regressions = [
+        {
+          name: 'FCP',
+          baseline: 1000,
+          current: 1060,
+          growthFraction: 0.06,
+          threshold: 0.05,
+          message: 'FCP regressed 6.0% (1000ms → 1060ms, threshold: 5%)',
+        },
+      ];
+      const fired = evaluateAlerts(collector, undefined, regressions);
+      const alert = fired.find((a) => a.ruleId === 'vital_fcp_regression');
+      expect(alert).toBeDefined();
+      expect(alert!.severity).toBe('warn');
+      expect(alert!.message).toContain('FCP');
+    });
+  });
+
+  // ── Rule: vital_lcp_regression ────────────────────────────
+
+  describe('vital_lcp_regression', () => {
+    it('does not fire when no LCP regression exists', () => {
+      const regressions = [
+        {
+          name: 'FCP',
+          baseline: 1000,
+          current: 1060,
+          growthFraction: 0.06,
+          threshold: 0.05,
+          message: 'FCP regressed 6.0%',
+        },
+      ];
+      const fired = evaluateAlerts(collector, undefined, regressions);
+      expect(fired.find((a) => a.ruleId === 'vital_lcp_regression')).toBeUndefined();
+    });
+
+    it('fires when LCP regression is present', () => {
+      const regressions = [
+        {
+          name: 'LCP',
+          baseline: 2000,
+          current: 2080,
+          growthFraction: 0.04,
+          threshold: 0.03,
+          message: 'LCP regressed 4.0% (2000ms → 2080ms, threshold: 3%)',
+        },
+      ];
+      const fired = evaluateAlerts(collector, undefined, regressions);
+      const alert = fired.find((a) => a.ruleId === 'vital_lcp_regression');
+      expect(alert).toBeDefined();
+      expect(alert!.severity).toBe('critical');
+      expect(alert!.message).toContain('LCP');
+    });
+  });
 });

--- a/tests/lib/perf-budget.test.ts
+++ b/tests/lib/perf-budget.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  checkBundleBudget,
+  detectVitalRegression,
+  DEFAULT_BUNDLE_BUDGET_BYTES,
+  DEFAULT_VITAL_THRESHOLDS,
+  type VitalBaseline,
+} from '@/lib/perf-budget';
+import { logger } from '@/lib/logger';
+
+// Suppress logger output during tests
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    metric: vi.fn(),
+  },
+}));
+
+// ── checkBundleBudget ───────────────────────────────────────
+
+describe('checkBundleBudget', () => {
+  it('passes when bundle is under budget', () => {
+    const result = checkBundleBudget(300 * 1024); // 300 KB
+    expect(result.pass).toBe(true);
+    expect(result.deltaBytes).toBeLessThan(0);
+    expect(result.message).toContain('OK');
+  });
+
+  it('passes when bundle is exactly at budget', () => {
+    const result = checkBundleBudget(DEFAULT_BUNDLE_BUDGET_BYTES);
+    expect(result.pass).toBe(true);
+    expect(result.deltaBytes).toBe(0);
+  });
+
+  it('fails when bundle exceeds budget', () => {
+    const result = checkBundleBudget(350 * 1024); // 350 KB
+    expect(result.pass).toBe(false);
+    expect(result.deltaBytes).toBeGreaterThan(0);
+    expect(result.message).toContain('OVER budget');
+  });
+
+  it('uses custom budget when provided', () => {
+    const customBudget = 200 * 1024; // 200 KB
+    const result = checkBundleBudget(150 * 1024, customBudget);
+    expect(result.pass).toBe(true);
+    expect(result.budgetBytes).toBe(customBudget);
+  });
+
+  it('reports correct delta and message for oversize', () => {
+    const actual = 330 * 1024;
+    const result = checkBundleBudget(actual);
+    expect(result.actualBytes).toBe(actual);
+    expect(result.budgetBytes).toBe(DEFAULT_BUNDLE_BUDGET_BYTES);
+    expect(result.deltaBytes).toBe(actual - DEFAULT_BUNDLE_BUDGET_BYTES);
+    expect(result.message).toContain('330.0');
+    expect(result.message).toContain('320.0');
+  });
+
+  it('logs a warning when bundle exceeds budget', () => {
+    checkBundleBudget(350 * 1024);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'perf_budget.bundle_exceeded',
+      expect.objectContaining({ actualBytes: 350 * 1024 }),
+    );
+  });
+});
+
+// ── detectVitalRegression ───────────────────────────────────
+
+describe('detectVitalRegression', () => {
+  it('returns pass when vitals are within threshold', () => {
+    const baselines: VitalBaseline[] = [
+      { name: 'FCP', value: 1000 },
+      { name: 'LCP', value: 2000 },
+    ];
+    // FCP grew 4 % (threshold 5 %), LCP grew 2 % (threshold 3 %)
+    const current = new Map([
+      ['FCP', 1040],
+      ['LCP', 2040],
+    ]);
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(true);
+    expect(result.regressions).toHaveLength(0);
+  });
+
+  it('detects FCP regression above 5 %', () => {
+    const baselines: VitalBaseline[] = [{ name: 'FCP', value: 1000 }];
+    const current = new Map([['FCP', 1060]]); // 6 % growth
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(false);
+    expect(result.regressions).toHaveLength(1);
+    expect(result.regressions[0].name).toBe('FCP');
+    expect(result.regressions[0].growthFraction).toBeCloseTo(0.06, 2);
+    expect(result.regressions[0].message).toContain('FCP');
+    expect(result.regressions[0].message).toContain('6.0%');
+  });
+
+  it('detects LCP regression above 3 %', () => {
+    const baselines: VitalBaseline[] = [{ name: 'LCP', value: 2000 }];
+    const current = new Map([['LCP', 2080]]); // 4 % growth
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(false);
+    expect(result.regressions).toHaveLength(1);
+    expect(result.regressions[0].name).toBe('LCP');
+    expect(result.regressions[0].threshold).toBe(0.03);
+  });
+
+  it('detects multiple regressions at once', () => {
+    const baselines: VitalBaseline[] = [
+      { name: 'FCP', value: 1000 },
+      { name: 'LCP', value: 2000 },
+    ];
+    const current = new Map([
+      ['FCP', 1100], // 10 %
+      ['LCP', 2100], // 5 %
+    ]);
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(false);
+    expect(result.regressions).toHaveLength(2);
+  });
+
+  it('ignores vitals not in currentValues', () => {
+    const baselines: VitalBaseline[] = [{ name: 'FCP', value: 1000 }];
+    const current = new Map<string, number>(); // empty
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(true);
+    expect(result.regressions).toHaveLength(0);
+  });
+
+  it('ignores vitals not in thresholds', () => {
+    const baselines: VitalBaseline[] = [{ name: 'CLS', value: 0.1 }];
+    const current = new Map([['CLS', 0.5]]); // massive growth but no CLS threshold
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(true);
+  });
+
+  it('skips baseline with value 0 (avoids division by zero)', () => {
+    const baselines: VitalBaseline[] = [{ name: 'FCP', value: 0 }];
+    const current = new Map([['FCP', 1000]]);
+    const result = detectVitalRegression(baselines, current);
+    expect(result.pass).toBe(true);
+  });
+
+  it('accepts custom thresholds', () => {
+    const baselines: VitalBaseline[] = [{ name: 'FCP', value: 1000 }];
+    const current = new Map([['FCP', 1020]]); // 2 % growth
+    // With a 1 % threshold, this should trigger
+    const result = detectVitalRegression(baselines, current, { FCP: 0.01 });
+    expect(result.pass).toBe(false);
+    expect(result.regressions[0].threshold).toBe(0.01);
+  });
+
+  it('logs a warning for each regression', () => {
+    const baselines: VitalBaseline[] = [{ name: 'FCP', value: 1000 }];
+    const current = new Map([['FCP', 1100]]);
+    detectVitalRegression(baselines, current);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'perf_budget.vital_regression',
+      expect.objectContaining({ vital: 'FCP' }),
+    );
+  });
+
+  it('uses DEFAULT_VITAL_THRESHOLDS by default', () => {
+    expect(DEFAULT_VITAL_THRESHOLDS.FCP).toBe(0.05);
+    expect(DEFAULT_VITAL_THRESHOLDS.LCP).toBe(0.03);
+  });
+});


### PR DESCRIPTION
- Upgrade k6 from 50 constant-vus to 500 ramping-vus (60s ramp-up, 3m sustained, 60s ramp-down)
- Tighten thresholds: checkout p95 < 500ms, browse p95 < 500ms, search p95 < 1s
- Add lib/perf-budget.ts: bundle size guard (320KB) + Web Vitals regression detection (FCP >5%, LCP >3%)
- Extend lib/alerts.ts: 2 new alert rules (vital_fcp_regression, vital_lcp_regression)
- Tests: 16 perf-budget tests + 6 new alerts tests (712 total, all green)



